### PR TITLE
Merge marsh-edits into master

### DIFF
--- a/dotnet/move/GitMover/GitMover.cs
+++ b/dotnet/move/GitMover/GitMover.cs
@@ -40,7 +40,7 @@ namespace CSITools
         private bool @continue;
         Repository repo;
         private string originalFileContents;
-        
+
         public string repoWorkingRoot { get; private set; }
 
         string gitUserName = "";
@@ -372,7 +372,11 @@ namespace CSITools
             }
         }
 
-        // removes everything from the end of a file link
+        /// <summary>
+        /// Removes everything from the end of a file link
+        /// </summary>
+        /// <param name="oldOutboundLink"></param>
+        /// <returns></returns>
         private string CleanURL(string oldOutboundLink)
         {
             if (oldOutboundLink.IndexOf(' ') != -1)
@@ -488,12 +492,14 @@ namespace CSITools
 
             foreach (IndexEntry file in repoFiles)
             {
+                string fileContent = File.ReadAllText(repo.Info.WorkingDirectory + file.Path);
+
                 //  if it has a match: focus!
-                if (justFilePattern.IsMatch(File.ReadAllText(repo.Info.WorkingDirectory + file.Path)))
+                if (justFilePattern.IsMatch(fileContent))
                 {
                     // get all matches in links
                     var oldInboundLinks = Regex.Match(
-                        File.ReadAllText(repo.Info.WorkingDirectory + file.Path),
+                        fileContent,
                         @"(?<=\]\()\S*" + originalFileName
                     );
 
@@ -501,7 +507,7 @@ namespace CSITools
                     {
                         // this means likely we have reference links. booo:
                         oldInboundLinks = Regex.Match(
-                            File.ReadAllText(repo.Info.WorkingDirectory + file.Path),
+                            fileContent,
                             @"(?<=\]:).+?" + originalFileName
                         );
                         if (!oldInboundLinks.Success)
@@ -523,13 +529,12 @@ namespace CSITools
                     }
                     newInboundLink = newInboundLink.Replace(@"\", @"/");
 
-
                     // for each link match, replace that with the new, relative link.
                     // BUG: if the file is the same name but in a different location, we need to do this only once for all things.
                     string replaceText = "";
                     try
                     {
-                        replaceText = File.ReadAllText(repo.Info.WorkingDirectory + file.Path).Replace(oldInboundLinks.Value, newInboundLink);
+                        replaceText = fileContent.Replace(oldInboundLinks.Value, newInboundLink);
                     }
                     catch (Exception ex)
                     {

--- a/dotnet/move/GitMover/GitMover.cs
+++ b/dotnet/move/GitMover/GitMover.cs
@@ -642,7 +642,9 @@ namespace CSITools
 
             foreach (Match currentInternalMediaString in imagelinks)
             {
-                string oldMediaLink = (Regex.Match(currentInternalMediaString.Value, @"(?<=\]\().+?(?=\))")).Value;
+                // regex pulls file path from strings like: [JobStates](./media/storage-import-export-retrieving-state-info-for-a-job/JobStates.png "JobStates")
+                // old regex: (?<=\]\().+?(?=\)) ==> misses links that includes titles, like the above with "JobStates"
+                string oldMediaLink = (Regex.Match(currentInternalMediaString.Value, @"(?<=\]\().+?(?=[\ \)])")).Value;
 
                 // GetRelativePath takes an absolute path to a file and an absolute path to a directory
                 // and returns the relative path from the latter to the former.
@@ -695,7 +697,9 @@ namespace CSITools
             foreach (Match item in imagelinks)
             {
                 // relative path from the original file directory
-                string searchPath = (Regex.Match(item.Value, @"(?<=\]\().+?(?=\))")).Value;
+                // regex pulls file path from strings like: [JobStates](./media/storage-import-export-retrieving-state-info-for-a-job/JobStates.png "JobStates")
+                // old regex: (?<=\]\().+?(?=\)) ==> misses links that includes titles, like the above with "JobStates"
+                string searchPath = (Regex.Match(item.Value, @"(?<=\]\().+?(?=[\ \)])")).Value;
 
                 // original directory and file name
                 string sourceDir = Path.GetDirectoryName(sourcePattern);

--- a/dotnet/move/GitMover/GitMover.cs
+++ b/dotnet/move/GitMover/GitMover.cs
@@ -565,14 +565,15 @@ namespace CSITools
             {
                 string oldPath = mediaFileEntry.Key.ToString();
                 string newPath = mediaFileEntry.Value.ToString().ToLower();
+                string newMediaDir = Path.GetDirectoryName(repo.Info.WorkingDirectory + newPath);
 
                 // make sure the moving directory exists, or EVERYTHING WILL FAIL.
-                if (!Directory.Exists(Path.GetDirectoryName(newPath)))
+                if (!Directory.Exists(newMediaDir))
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(repo.Info.WorkingDirectory + newPath));
+                    Directory.CreateDirectory(newMediaDir);
                 }
 
-                if (File.Exists(repo.Info.WorkingDirectory + oldPath) && Directory.Exists(Path.GetDirectoryName(newPath)))
+                if (File.Exists(repo.Info.WorkingDirectory + oldPath) && Directory.Exists(newMediaDir))
                 {
                     try
                     {

--- a/dotnet/move/move/Options.cs
+++ b/dotnet/move/move/Options.cs
@@ -13,10 +13,10 @@ namespace links
         [Option('r', "repo-directory", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
         public string RepoDir { get; set; }
 
-        [Option('s', "source", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = true, DefaultValue = "")]
+        [Option('s', "source", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
         public string Source { get; set; }
 
-        [Option('d', "destination", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = true, DefaultValue = "")]
+        [Option('d', "destination", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
         public string Destination { get; set; }
 
         [Option('h', "help", HelpText = "Displays this help for \"move\".", Required = false, DefaultValue = false)]

--- a/dotnet/move/move/Options.cs
+++ b/dotnet/move/move/Options.cs
@@ -13,10 +13,10 @@ namespace links
         [Option('r', "repo-directory", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
         public string RepoDir { get; set; }
 
-        [Option('s', "source", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
+        [Option('s', "source", HelpText = "The current path of the file to be moved, relative to the repo-directory (e.g. articles/batch/myarticle.md).", Required = false, DefaultValue = "")]
         public string Source { get; set; }
 
-        [Option('d', "destination", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
+        [Option('d', "destination", HelpText = "The new path for the file, relative to the repo-directory (e.g. articles/batch/newdir/myarticle.md).", Required = false, DefaultValue = "")]
         public string Destination { get; set; }
 
         [Option('h', "help", HelpText = "Displays this help for \"move\".", Required = false, DefaultValue = false)]

--- a/dotnet/move/move/Options.cs
+++ b/dotnet/move/move/Options.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace links
+{
+    internal class Options
+    {
+        [Option('r', "repo-directory", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = false, DefaultValue = "")]
+        public string RepoDir { get; set; }
+
+        [Option('s', "source", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = true, DefaultValue = "")]
+        public string Source { get; set; }
+
+        [Option('d', "destination", HelpText = "Specifies the root directory of the repo to use; default is current directory.", Required = true, DefaultValue = "")]
+        public string Destination { get; set; }
+
+        [Option('h', "help", HelpText = "Displays this help for \"move\".", Required = false, DefaultValue = false)]
+        public bool ShowHelp { get; set; }
+
+        [Option('f', "redirect-file", HelpText = "Indicates that a moved file should be replaced with a redirect file to the new target. Default is false.", Required = false, DefaultValue = false)]
+        public bool Redirect { get; set; }
+
+        [Option('c', "continue", HelpText = "Indicates that should a non-fatal error occur, as much work as is possible will complete and the error is reported for follow-up. Default is false.", Required = false, DefaultValue = true)]
+        public bool Continue { get; set; }
+    }
+}

--- a/dotnet/move/move/Options.cs
+++ b/dotnet/move/move/Options.cs
@@ -25,7 +25,10 @@ namespace links
         [Option('f', "redirect-file", HelpText = "Indicates that a moved file should be replaced with a redirect file to the new target. Default is false.", Required = false, DefaultValue = false)]
         public bool Redirect { get; set; }
 
-        [Option('c', "continue", HelpText = "Indicates that should a non-fatal error occur, as much work as is possible will complete and the error is reported for follow-up. Default is false.", Required = false, DefaultValue = true)]
+        [Option('c', "continue", HelpText = "Indicates that should a non-fatal error occur, as much work as is possible will complete and the error is reported for follow-up. Default is true.", Required = false, DefaultValue = true)]
         public bool Continue { get; set; }
+
+        [Option('t', "do-commit", HelpText = "Specifies whether changes should be automatically committed via 'git commit'. Default is false.", Required = false, DefaultValue = false)]
+        public bool DoCommit { get; set; }
     }
 }

--- a/dotnet/move/move/Program.cs
+++ b/dotnet/move/move/Program.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
-using Mono.Options;
+using CommandLine;
 using CSITools;
-
 
 /*
 SPEC:
@@ -19,7 +19,6 @@ SPEC:
     2. Algorithm
         a) takes a file list as an argument in regular path format.
         b) takes a directory to place them in
-
  */
 
 namespace links
@@ -27,91 +26,67 @@ namespace links
     class MainClass
     {
 
-        private static bool redirects = false;
-        private static bool @continue = false;
-
         public static void Main(string[] args)
         {
-            string workingRepoDir = Directory.GetCurrentDirectory() + @"\";
-            bool show_help = false;
+            string repoDir = "";
 
-            var p = new OptionSet()
-            { 
-                /*{
-                    "d|directory",
-                    "Specifies the root directory of the repo to use; default is current directory.",
-                    (string v) => workingRepoDir = v
-                },
-                */
-                {
-                    "h|help",
-                    "Displays this help for \"move\"",
-                    v => show_help = v != null
-                },
-                { "r|redirect", "Indicates that moved file should be replaced with a redirect file to the new target; default is false.", v => redirects = true  },
-                { "c|continue", "Indicates that should a non-fatal error occur, as much work as is possible will complete and the error is reported for followup. Default is false.", v => @continue = true }
-            };
-
-            List<string> argList;
-
-            try {
-                argList = p.Parse (args);
-                Console.WriteLine(args);
-            }
-            catch (OptionException e) {
-                Console.Write ("move: ");
-                Console.WriteLine (e.Message);
-                Console.WriteLine ("Try 'move --help' for more information.");
-                return;
-            }
-
-            if (show_help) {
-                ShowHelp (p);
-                return;
-            }
-
-            GitMover mover = null;  
+            Options options = new Options();
             try
             {
-                mover = new GitMover(workingRepoDir, argList[0], argList[1], redirects, @continue);
-                mover.Move();
-                mover.Dispose();
+                if (CommandLine.Parser.Default.ParseArguments(args, options))
+                {
+                    if (options.ShowHelp)
+                    {
+                        Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(options));
+                    }
+
+                    if (String.IsNullOrEmpty(options.RepoDir))
+                    {
+                        // Use the current directory if the user didn't specify --repo-dir
+                        repoDir = Directory.GetCurrentDirectory() + @"\";
+                    }
+                    else
+                    {
+                        repoDir = options.RepoDir + @"\";
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Write("move: ");
+                Console.WriteLine(e.Message);
+                Console.WriteLine("Try 'move --help' for more information.");
+                return;
+            }
+            
+            GitMover mover = null;
+            try
+            {
+                using (mover = new GitMover(repoDir, options.Source, options.Destination, options.Redirect, options.Continue))
+                {
+                    mover.Move();
+                }
             }
             catch (Exception ex)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("Error: {0} ", ex.Message);
                 Console.ResetColor();
-                //ShowHelp(p);
+
                 if (mover != null)
                 {
                     mover.Unwind();
                     mover.Dispose();
                 }
+
+                // Pause to allow user to view exception message
+                Console.WriteLine("\nHit ENTER to exit...");
+                Console.ReadLine();
             }
-            Console.WriteLine("done");
-            // Console.ReadLine();
 
-
+            Console.WriteLine("Done.");
         }
-
-        static void ShowHelp (OptionSet p)
-        {
-            Console.WriteLine ("Usage: move <source filespec> <target filespec>");
-            Console.WriteLine();
-            Console.WriteLine ("Where <source filespec> is the path from the root of a documentation directory, and <target filespec> is the same. Moves a single markdown file to the specified path, including media files, and rewrite all inbound links.");
-            Console.WriteLine ("NOTE: This program moves one file at a time.");
-            Console.WriteLine();
-            Console.WriteLine("Example in CMD.EXE: ");
-            Console.WriteLine();
-            Console.WriteLine("\t{0}> move.exe \"{1}\" \"{2}\"", @"C:\github\azure-docs-pr", @"articles\file.md", @"articles\directory\file.md");
-            Console.WriteLine();
-            Console.WriteLine ("Options:");
-            p.WriteOptionDescriptions (Console.Out);
-        }
-
     }
-
 }
 
 

--- a/dotnet/move/move/Program.cs
+++ b/dotnet/move/move/Program.cs
@@ -69,26 +69,29 @@ namespace links
             GitMover mover = null;
             try
             {
-                using (mover = new GitMover(repoDir, options.Source, options.Destination, options.Redirect, options.Continue))
-                {
-                    mover.Move();
-                }
+                mover = new GitMover(repoDir, options.Source, options.Destination, options.Redirect, options.Continue, options.DoCommit);
+                mover.Move();
             }
             catch (Exception ex)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("Error: {0} ", ex.Message);
+                Console.WriteLine("Stack trace: {0} ", ex.StackTrace);
                 Console.ResetColor();
 
                 if (mover != null)
                 {
+                    Console.WriteLine("Unwinding...");
                     mover.Unwind();
-                    mover.Dispose();
                 }
 
                 // Pause to allow user to view exception message
                 Console.WriteLine("\nHit ENTER to exit...");
                 Console.ReadLine();
+            }
+            finally
+            {
+                mover.Dispose();
             }
 
             Console.WriteLine("Done.");

--- a/dotnet/move/move/Program.cs
+++ b/dotnet/move/move/Program.cs
@@ -91,7 +91,8 @@ namespace links
             }
             finally
             {
-                mover.Dispose();
+                if(mover != null)
+                    mover.Dispose();
             }
 
             Console.WriteLine("Done.");

--- a/dotnet/move/move/Program.cs
+++ b/dotnet/move/move/Program.cs
@@ -38,6 +38,8 @@ namespace links
                     if (options.ShowHelp)
                     {
                         Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(options));
+                        //Exit the app without doing anything
+                        return;
                     }
 
                     if (String.IsNullOrEmpty(options.RepoDir))
@@ -49,6 +51,11 @@ namespace links
                     {
                         repoDir = options.RepoDir + @"\";
                     }
+                }
+                else
+                {
+                    Console.WriteLine("Command line arguments not parsed successfully. Raw args were:");
+                    Console.WriteLine(String.Join(" | ", args));
                 }
             }
             catch (Exception e)

--- a/dotnet/move/move/Properties/AssemblyInfo.cs
+++ b/dotnet/move/move/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/dotnet/move/move/Properties/AssemblyInfo.cs
+++ b/dotnet/move/move/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("move")]
+[assembly: AssemblyTitle("movemd")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("move")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyProduct("movemd")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/dotnet/move/move/move.csproj
+++ b/dotnet/move/move/move.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>move</RootNamespace>
-    <AssemblyName>move</AssemblyName>
+    <AssemblyName>movemd</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/dotnet/move/move/move.csproj
+++ b/dotnet/move/move/move.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,13 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Options, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Options.4.4.0.0\lib\net4-client\Mono.Options.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -72,7 +71,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/dotnet/move/move/packages.config
+++ b/dotnet/move/move/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net461" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net461" />
-  <package id="Mono.Options" version="4.4.0.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net461" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Merges the following modifications into the master branch of mmacy/gitwork.

* Update to latest **LibGit2Sharp**
* Switch command line arg parser to [CommandLine (NuGet)](https://github.com/gsscoder/commandline)
* Fix destination media directory creation on not-exist
* Minimize file open/read/close operations
* Glean git user name and email from git config
* Add `--do-commit` command arg (defaults false)
* Additional prints to STDOUT on moves and errors
* Shift mover.Dispose() to a finally block
* Change file name `move.exe` to `movemd.exe` (move.exe conflicted with Windows' native move.exe)
* regex fix for links that include titles, as in `[blah blah](./my/file.md "link title")`